### PR TITLE
Remove simulator excluded archs.

### DIFF
--- a/JitsiMeetSDK.podspec.tpl
+++ b/JitsiMeetSDK.podspec.tpl
@@ -11,7 +11,4 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '12.0'
 
   s.vendored_frameworks = 'Frameworks/JitsiMeetSDK.xcframework', 'Frameworks/WebRTC.xcframework'
-  
-  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end


### PR DESCRIPTION
This will allow the M1 simulator to work following on from https://github.com/jitsi/jitsi-meet/pull/10984 when using the pod as a dependency.

This change is untested on my side right now.