### PR TITLE
Remove duplicated vendored_frameworks

### DIFF
--- a/JitsiMeetSDK.podspec.tpl
+++ b/JitsiMeetSDK.podspec.tpl
@@ -9,8 +9,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/jitsi/jitsi-meet-ios-sdk-releases.git', :tag => s.version }
   s.platform         = :ios, '15.1'
   s.swift_version    = '5'
-  s.vendored_frameworks = 'Frameworks/JitsiMeetSDK.xcframework'
-  s.vendored_frameworks = 'Frameworks/hermes.xcframework'
+  s.vendored_frameworks = ['Frameworks/JitsiMeetSDK.xcframework', 'Frameworks/hermes.xcframework']
   s.dependency 'Giphy', '2.2.12'
   s.dependency 'JitsiWebRTC', '~> 124.0'
 end

--- a/JitsiMeetSDKLite.podspec.tpl
+++ b/JitsiMeetSDKLite.podspec.tpl
@@ -9,7 +9,6 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/jitsi/jitsi-meet-ios-sdk-releases.git', :tag => s.version }
   s.platform         = :ios, '15.1'
   s.swift_version    = '5'
-  s.vendored_frameworks = 'lite/Frameworks/JitsiMeetSDK.xcframework'
-  s.vendored_frameworks = 'lite/Frameworks/hermes.xcframework'
+  s.vendored_frameworks = ['lite/Frameworks/JitsiMeetSDK.xcframework', 'lite/Frameworks/hermes.xcframework']
   s.dependency 'JitsiWebRTC', '~> 124.0'
 end


### PR DESCRIPTION
The original configuration had two entries for vendored_frameworks, which would cause only the last one to be applied. This has been fixed by combining the frameworks into a single array.