### PR TITLE
Point hermes binary target at hermesvm.xcframework

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,14 +20,14 @@ let package = Package(
             path: "Frameworks/JitsiMeetSDK.xcframework"
         ),
         .binaryTarget(
-            name: "hermesvm",
+            name: "hermes",
             path: "Frameworks/hermesvm.xcframework"
         ),
         .target(
             name: "JitsiMeetSDKWrapper",
             dependencies: [
                 .target(name: "JitsiMeetSDK"),
-                .target(name: "hermesvm"),
+                .target(name: "hermes"),
                 .product(name: "WebRTC", package: "webrtc"),
                 .product(name: "GiphyUISDK", package: "giphy-ios-sdk")
             ],

--- a/Package.swift
+++ b/Package.swift
@@ -20,14 +20,14 @@ let package = Package(
             path: "Frameworks/JitsiMeetSDK.xcframework"
         ),
         .binaryTarget(
-            name: "hermes",
-            path: "Frameworks/hermes.xcframework"
+            name: "hermesvm",
+            path: "Frameworks/hermesvm.xcframework"
         ),
         .target(
             name: "JitsiMeetSDKWrapper",
             dependencies: [
                 .target(name: "JitsiMeetSDK"),
-                .target(name: "hermes"),
+                .target(name: "hermesvm"),
                 .product(name: "WebRTC", package: "webrtc"),
                 .product(name: "GiphyUISDK", package: "giphy-ios-sdk")
             ],

--- a/lite/Package.swift
+++ b/lite/Package.swift
@@ -19,14 +19,14 @@ let package = Package(
             path: "../lite/Frameworks/JitsiMeetSDK.xcframework"
         ),
         .binaryTarget(
-            name: "hermes",
-            path: "../lite/Frameworks/hermes.xcframework"
+            name: "hermesvm",
+            path: "../lite/Frameworks/hermesvm.xcframework"
         ),
         .target(
             name: "JitsiMeetSDKWrapper",
             dependencies: [
                 .target(name: "JitsiMeetSDK"),
-                .target(name: "hermes"),
+                .target(name: "hermesvm"),
                 .product(name: "WebRTC", package: "webrtc")
             ],
             path: "Sources"

--- a/lite/Package.swift
+++ b/lite/Package.swift
@@ -19,14 +19,14 @@ let package = Package(
             path: "../lite/Frameworks/JitsiMeetSDK.xcframework"
         ),
         .binaryTarget(
-            name: "hermesvm",
+            name: "hermes",
             path: "../lite/Frameworks/hermesvm.xcframework"
         ),
         .target(
             name: "JitsiMeetSDKWrapper",
             dependencies: [
                 .target(name: "JitsiMeetSDK"),
-                .target(name: "hermesvm"),
+                .target(name: "hermes"),
                 .product(name: "WebRTC", package: "webrtc")
             ],
             path: "Sources"


### PR DESCRIPTION
## Problem

Swift Package Manager consumers of `JitsiMeetSDK` 13.x cannot resolve the package:

```
local binary target 'hermes' at '.../Frameworks/hermes.xcframework'
does not contain a binary artifact. fatalError
```

Since **13.0.0** the shipped artifact is `hermesvm.xcframework` (the React Native 0.85 Hermes rename), but both `Package.swift` manifests still point their `hermes` binary target at the now-nonexistent `hermes.xcframework`.

| ref | `Frameworks/` contains | manifest path | SPM resolve |
|---|---|---|---|
| 12.1.1 | `hermes.xcframework` | `hermes.xcframework` | works |
| 13.0.0 | `hermesvm.xcframework` | `hermes.xcframework` | fails |
| 13.1.0 | `hermesvm.xcframework` | `hermes.xcframework` | fails |
| master | `hermesvm.xcframework` | `hermes.xcframework` | fails |

CocoaPods is unaffected — `JitsiMeetSDK.podspec` already tracks the rename, so only SPM consumers are broken.

## Fix

One line per manifest — repoint the path, leaving the target name `hermes` as-is:

- `Package.swift` → `Frameworks/hermesvm.xcframework`
- `lite/Package.swift` → `../lite/Frameworks/hermesvm.xcframework`

The target name is only a label for a local (path-based) `binaryTarget`; SwiftPM does not require it to match the artifact filename (that constraint applies to remote `url`+`checksum` targets). The linked framework name still comes from the xcframework itself, so consumers get `hermesvm.framework` either way — keeping the name means **no consumer-visible change and nothing to rebuild**.

## Verification

Applied to a local checkout of tag `13.1.0` and built the SwiftUI consumer sample (`jitsi-meet-sdk-samples/ios/swiftui`) against it:

```
xcodebuild -project JitsiSwiftUIDemo.xcodeproj -scheme JitsiSwiftUIDemo \
  -destination 'generic/platform=iOS Simulator' build
** BUILD SUCCEEDED **
```

`JitsiSwiftUIDemo.app/Frameworks/hermesvm.framework` is embedded as expected. Without the change, resolution fails before any compilation.

Because this touches only the manifest and none of the binary artifacts, the existing `13.0.0`/`13.1.0` tags can be re-pointed to include it — no SDK re-release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)